### PR TITLE
Use UTF-8 to encode text and html parts.

### DIFF
--- a/extension/core/src/main/java/org/camunda/bpm/extension/mail/MailContentType.java
+++ b/extension/core/src/main/java/org/camunda/bpm/extension/mail/MailContentType.java
@@ -14,8 +14,8 @@ package org.camunda.bpm.extension.mail;
 
 public enum MailContentType {
 
-  TEXT_PLAIN("text/plain"),
-  TEXT_HTML("text/html"),
+  TEXT_PLAIN("text/plain; charset=utf-8"),
+  TEXT_HTML("text/html; charset=utf-8"),
   MULTIPART("multipart");
 
   private final String type;

--- a/extension/core/src/main/java/org/camunda/bpm/extension/mail/dto/Mail.java
+++ b/extension/core/src/main/java/org/camunda/bpm/extension/mail/dto/Mail.java
@@ -145,7 +145,7 @@ public class Mail implements Serializable {
   }
 
   protected static boolean isMultipartMessage(Message message) throws MessagingException, IOException {
-    return MailContentType.MULTIPART.match(message.getContentType())
+    return message.isMimeType("multipart")
         || message.getContent() instanceof Multipart;
   }
 
@@ -158,10 +158,10 @@ public class Mail implements Serializable {
 
     } else {
 
-      if (MailContentType.TEXT_PLAIN.match(part.getContentType())) {
+      if (part.isMimeType("text/plain")) {
         mail.text = (String) part.getContent();
 
-      } else if (MailContentType.TEXT_HTML.match(part.getContentType())) {
+      } else if (part.isMimeType("text/html")) {
         mail.html = (String) part.getContent();
       }
     }


### PR DESCRIPTION
This PR lets you use international characters in Mail messages