### PR TITLE
Add error details to exception message

### DIFF
--- a/extension/core/src/main/java/org/camunda/bpm/extension/mail/delete/DeleteMailConnector.java
+++ b/extension/core/src/main/java/org/camunda/bpm/extension/mail/delete/DeleteMailConnector.java
@@ -68,7 +68,7 @@ public class DeleteMailConnector extends AbstractConnector<DeleteMailRequest, Em
       return new EmptyResponse();
 
     } catch (Exception e) {
-      throw new MailConnectorException("failed to delete mails", e);
+      throw new MailConnectorException("Failed to delete mails: " + e.getMessage(), e);
     }
   }
 

--- a/extension/core/src/main/java/org/camunda/bpm/extension/mail/poll/PollMailConnector.java
+++ b/extension/core/src/main/java/org/camunda/bpm/extension/mail/poll/PollMailConnector.java
@@ -62,7 +62,7 @@ public class PollMailConnector extends AbstractConnector<PollMailRequest, PollMa
       return new PollMailResponse(messages, mailService, request.downloadAttachments(), getConfiguration().getAttachmentPath());
 
     } catch (Exception e) {
-      throw new MailConnectorException("failed to poll mails", e);
+      throw new MailConnectorException("Failed to poll mails: " + e.getMessage(), e);
     }
   }
 

--- a/extension/core/src/main/java/org/camunda/bpm/extension/mail/send/SendMailConnector.java
+++ b/extension/core/src/main/java/org/camunda/bpm/extension/mail/send/SendMailConnector.java
@@ -62,7 +62,7 @@ public class SendMailConnector extends AbstractConnector<SendMailRequest, EmptyR
       invocation.proceed();
 
     } catch (Exception e) {
-      throw new MailConnectorException("failed to send mail", e);
+      throw new MailConnectorException("Failed to send mail: " + e.getMessage(), e);
     }
 
     return new EmptyResponse();


### PR DESCRIPTION
We are currently using this extension to send mails from our Camunda BPM processes.

If sending a mail fails for any reason, e.g. a failed authentication, a `MailConnectorException` is thrown, with the underlying exception in the stack trace. This underlying exception generally provides more details on what caused the problem (e.g. `javax.mail.AuthenticationFailedException: 535 5.7.3 Authentication unsuccessful` in the authentication example).

---

This pull requests proposes to **append the underlying exception message to the message of the `MailConnectorException`**.

We see two benefits of this:

1. When catching the exception inside a Camunda BPM process, without creating a custom incident handler, we **don't seem to have a clear way to access the stack trace**, and can only access the exception message directly. With this change, distinguishing between different error types will be easily possible.

2. In Camunda cockpit, the exception message is shown in the incident list, and accessing the stack trace requires further drill-down. With this change, **scanning the incident list for a specific error type**, and quickly identifying the nature of a problem will be much faster.

Thanks for considering this change, please let me know if you have any concerns!